### PR TITLE
Use latest tag for distroless-python

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -18,7 +18,7 @@ ENV HF_HOME=/app/models
 
 RUN /app/venv/bin/python3 download_vit.py
 
-FROM public.ecr.aws/j9h1x6x3/distroless-python:3.11-deb12-7.11.24.1 as base
+FROM public.ecr.aws/j9h1x6x3/distroless-python:latest as base
 
 # Set platform-specific CHIPSET_ARCH
 FROM base as base-amd64


### PR DESCRIPTION
This makes it a lot easier in the incoming `build-dependencies.yml` action in the `masc` repo, as it doesn't have to update this separate repo, but can instead just pull it and rebuild it.