### PR TITLE
Bump fastapi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.110.1
+fastapi==0.115.4
 pillow==10.3.0
 torch==2.2.0
 torchvision==0.17.0


### PR DESCRIPTION
To address this vuln:
![Screenshot 2024-11-08 at 1 46 05 PM](https://github.com/user-attachments/assets/2dc0c466-29e9-4a01-8026-17e3c180c240)

Seems to work fine when testing locally
