### PR TITLE
Upgrade transformers to CVE free version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi==0.115.4
 pillow==10.3.0
 torch==2.2.0
 torchvision==0.17.0
-transformers==4.40.2
+transformers==4.48.0
 uvicorn==0.27.0
 numpy<2


### PR DESCRIPTION
This PR will upgrade the Transformers python requirement to remediate CVE-2024-11392, CVE-2024-11393, & CVE-2024-11394. 

Subsequent PR will be submitted in the Conduit repo to update the docker versions.yaml