### PR TITLE
Explicitly upgrade h11 for CVE remediation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ torchvision==0.21.0
 transformers==4.48.0
 uvicorn==0.27.0
 numpy<2
+# Sub-dependency for CVE remediation
+h11>=0.16.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the h11 package (version 0.16.0 or higher) as a new dependency to address security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->